### PR TITLE
Enable fast/minimum caching

### DIFF
--- a/.github/compose/cache-npm/action.yaml
+++ b/.github/compose/cache-npm/action.yaml
@@ -16,6 +16,7 @@ runs:
       env:
         CACHE_KEY: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
         GH_TOKEN: ${{ inputs.token }}
+        GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         if gh extension list | grep -q "gh-actions-cache"
           then echo "already installed"

--- a/.github/compose/cache-npm/action.yaml
+++ b/.github/compose/cache-npm/action.yaml
@@ -13,7 +13,7 @@ runs:
       shell: bash
       id: check-cache-available
       env:
-        cache-key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('npm/package-lock.json') }}
+        cache-key: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
         GH_TOKEN: ${{ inputs.token}}
       run: |
           if gh extension list | grep -q "gh-actions-cache"

--- a/.github/compose/cache-npm/action.yaml
+++ b/.github/compose/cache-npm/action.yaml
@@ -12,11 +12,9 @@ runs:
     - name: check cache is available test
       shell: bash
       id: check-cache-available
-      working-directory: npm
       env:
         CACHE_KEY: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
         GH_TOKEN: ${{ inputs.token }}
-        GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         if gh extension list | grep -q "gh-actions-cache"
           then echo "already installed"
@@ -32,41 +30,25 @@ runs:
       run: |
           echo ${{ steps.check-cache-available.outputs.cache }}
 
-    # - name: check cache is available
-    #   shell: bash
-    #   id: check-cache-available
-    #   env:
-    #     cache-key: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
-    #     GH_TOKEN: ${{ inputs.token}}
-    #   run: |
-    #       if gh extension list | grep -q "gh-actions-cache"
-    #         then echo "already installed"
-    #         else gh extension install actions/gh-actions-cache
-    #       fi
+    - uses: actions/cache@v3
+      if: steps.check-cache-available.outputs.cache == 'miss'
+      id: cache-npm
+      env:
+        cache-name: cache-npm
+      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action
+      with:
+        path: |
+          ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('npm/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
 
-    #       if gh actions-cache list "${{ env.cache-key }}" | grep -q "${{ env.cache-key }}"
-    #         then echo "::set-output name=cache::hit"
-    #         else echo "::set-output name=cache::miss"
-    #       fi
-    # - uses: actions/cache@v3
-    #   if: steps.check-cache-available.outputs.cache == 'miss'
-    #   id: cache-npm
-    #   env:
-    #     cache-name: cache-npm
-    #   # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action
-    #   with:
-    #     path: |
-    #       ~/.npm
-    #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('npm/package-lock.json') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-build-${{ env.cache-name }}-
-    #       ${{ runner.os }}-build-
-    #       ${{ runner.os }}-
-
-    # # Because it restores ~/.npm, it always needs `npm ci` to recover ./node-modules.
-    # # Instead, we can cache `node-modules` directly. See: https://zenn.dev/odan/scraps/81b2738864a908
-    # - name: npm ci
-    #   shell: bash
-    #   working-directory: npm
-    #   run: |
-    #     npm ci
+    # Because it only restores ~/.npm but, it always needs `npm ci` to recover ./node-modules.
+    # Instead, we can cache `node-modules` directly. See: https://zenn.dev/odan/scraps/81b2738864a908
+    - name: npm ci
+      shell: bash
+      working-directory: npm
+      run: |
+        npm ci

--- a/.github/compose/cache-npm/action.yaml
+++ b/.github/compose/cache-npm/action.yaml
@@ -9,6 +9,7 @@ runs:
       id: check-cache-available
       env:
         cache-key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('npm/package-lock.json') }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
           if gh extension list | grep -q "gh-actions-cache"
             then gh extension install actions/gh-actions-cache

--- a/.github/compose/cache-npm/action.yaml
+++ b/.github/compose/cache-npm/action.yaml
@@ -4,7 +4,7 @@ description: 'Install node_modules'
 inputs:
   token:
       description: 'Your token'
-      default: ${{ secrets.GITHUB_TOKEN }}
+      required: true
 
 runs:
   using: "composite"

--- a/.github/compose/cache-npm/action.yaml
+++ b/.github/compose/cache-npm/action.yaml
@@ -4,7 +4,23 @@ description: 'Install node_modules'
 runs:
   using: "composite"
   steps:
+    - name: check cache is available
+      shell: bash
+      id: check-cache-available
+      env:
+        cache-key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('npm/package-lock.json') }}
+      run: |
+          if gh extension list | grep -q "gh-actions-cache"
+            then gh extension install actions/gh-actions-cache
+            else echo "already installed"
+          fi
+
+          if gh actions-cache list "${{ env.cache-key }}" | grep -q "${{ env.cache-key }}"
+            then echo "::set-output name=cache::hit"
+            else echo "::set-output name=cache::miss"
+          fi
     - uses: actions/cache@v3
+      if: steps.check-cache-available.outputs.cache == "miss"
       id: cache-npm
       env:
         cache-name: cache-npm

--- a/.github/compose/cache-npm/action.yaml
+++ b/.github/compose/cache-npm/action.yaml
@@ -1,6 +1,11 @@
 name: 'Install node_modules'
 description: 'Install node_modules'
 
+inputs:
+  token:
+      description: 'Your token'
+      default: ${{ secrets.GITHUB_TOKEN }}
+
 runs:
   using: "composite"
   steps:
@@ -9,7 +14,7 @@ runs:
       id: check-cache-available
       env:
         cache-key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('npm/package-lock.json') }}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ inputs.token}}
       run: |
           if gh extension list | grep -q "gh-actions-cache"
             then echo "already installed"

--- a/.github/compose/cache-npm/action.yaml
+++ b/.github/compose/cache-npm/action.yaml
@@ -20,7 +20,7 @@ runs:
             else echo "::set-output name=cache::miss"
           fi
     - uses: actions/cache@v3
-      if: steps.check-cache-available.outputs.cache == "miss"
+      if: steps.check-cache-available.outputs.cache == 'miss'
       id: cache-npm
       env:
         cache-name: cache-npm

--- a/.github/compose/cache-npm/action.yaml
+++ b/.github/compose/cache-npm/action.yaml
@@ -12,8 +12,8 @@ runs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
           if gh extension list | grep -q "gh-actions-cache"
-            then gh extension install actions/gh-actions-cache
-            else echo "already installed"
+            then echo "already installed"
+            else gh extension install actions/gh-actions-cache
           fi
 
           if gh actions-cache list "${{ env.cache-key }}" | grep -q "${{ env.cache-key }}"

--- a/.github/compose/cache-npm/action.yaml
+++ b/.github/compose/cache-npm/action.yaml
@@ -15,7 +15,7 @@ runs:
       working-directory: npm
       env:
         CACHE_KEY: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ inputs.token }}
       run: |
         if gh extension list | grep -q "gh-actions-cache"
           then echo "already installed"

--- a/.github/compose/cache-npm/action.yaml
+++ b/.github/compose/cache-npm/action.yaml
@@ -9,41 +9,63 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: check cache is available
+    - name: check cache is available test
       shell: bash
       id: check-cache-available
-      env:
-        cache-key: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
-        GH_TOKEN: ${{ inputs.token}}
-      run: |
-          if gh extension list | grep -q "gh-actions-cache"
-            then echo "already installed"
-            else gh extension install actions/gh-actions-cache
-          fi
-
-          if gh actions-cache list "${{ env.cache-key }}" | grep -q "${{ env.cache-key }}"
-            then echo "::set-output name=cache::hit"
-            else echo "::set-output name=cache::miss"
-          fi
-    - uses: actions/cache@v3
-      if: steps.check-cache-available.outputs.cache == 'miss'
-      id: cache-npm
-      env:
-        cache-name: cache-npm
-      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action
-      with:
-        path: |
-          ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('npm/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
-    # Because it restores ~/.npm, it always needs `npm ci` to recover ./node-modules.
-    # Instead, we can cache `node-modules` directly. See: https://zenn.dev/odan/scraps/81b2738864a908
-    - name: npm ci
-      shell: bash
       working-directory: npm
+      env:
+        CACHE_KEY: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        npm ci
+        if gh extension list | grep -q "gh-actions-cache"
+          then echo "already installed"
+          else gh extension install actions/gh-actions-cache
+        fi
+
+        if gh actions-cache list --key "${{ env.CACHE_KEY }}" | grep -q "${{ env.CACHE_KEY }}"
+          then echo "::set-output name=cache::hit"
+          else echo "::set-output name=cache::miss"
+        fi
+    - name: echo
+      shell: bash
+      run: |
+          echo ${{ steps.check-cache-available.outputs.cache }}
+
+    # - name: check cache is available
+    #   shell: bash
+    #   id: check-cache-available
+    #   env:
+    #     cache-key: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
+    #     GH_TOKEN: ${{ inputs.token}}
+    #   run: |
+    #       if gh extension list | grep -q "gh-actions-cache"
+    #         then echo "already installed"
+    #         else gh extension install actions/gh-actions-cache
+    #       fi
+
+    #       if gh actions-cache list "${{ env.cache-key }}" | grep -q "${{ env.cache-key }}"
+    #         then echo "::set-output name=cache::hit"
+    #         else echo "::set-output name=cache::miss"
+    #       fi
+    # - uses: actions/cache@v3
+    #   if: steps.check-cache-available.outputs.cache == 'miss'
+    #   id: cache-npm
+    #   env:
+    #     cache-name: cache-npm
+    #   # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action
+    #   with:
+    #     path: |
+    #       ~/.npm
+    #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('npm/package-lock.json') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-build-${{ env.cache-name }}-
+    #       ${{ runner.os }}-build-
+    #       ${{ runner.os }}-
+
+    # # Because it restores ~/.npm, it always needs `npm ci` to recover ./node-modules.
+    # # Instead, we can cache `node-modules` directly. See: https://zenn.dev/odan/scraps/81b2738864a908
+    # - name: npm ci
+    #   shell: bash
+    #   working-directory: npm
+    #   run: |
+    #     npm ci

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -18,6 +18,7 @@ jobs:
         working-directory: npm
         env:
           cache-key: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if gh extension list | grep -q "gh-actions-cache"
             then echo "already installed"

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -11,9 +11,9 @@ jobs:
   actions-test:
     name: actions-test
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # env:
+    #   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: check cache is available
@@ -48,7 +48,7 @@ jobs:
       - name: Cache Node packages
         uses: ./.github/compose/cache-npm
         with:
-          token: ${{ secrets.GH_TOKEN}}
+          token: ${{ secrets.GH_TOKEN }}
 
   build:
     name: build

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -29,6 +29,11 @@ jobs:
             then echo "::set-output name=cache::hit"
             else echo "::set-output name=cache::miss"
           fi
+          # FIXME: remove
+          gh actions-cache list --key "${{ env.CACHE_KEY }}"
+      - name: echo
+        run: |
+           echo ${{ steps.check-cache-available.outputs.cache }}
 
   install:
     name: install

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -11,6 +11,8 @@ jobs:
   actions-test:
     name: actions-test
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: check cache is available
@@ -18,7 +20,6 @@ jobs:
         working-directory: npm
         env:
           CACHE_KEY: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if gh extension list | grep -q "gh-actions-cache"
             then echo "already installed"

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -20,12 +20,12 @@ jobs:
           CACHE_KEY: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh extension list ${{ env.CACHE_KEY }} | grep -q "gh-actions-cache"
+          if gh extension list | grep -q "gh-actions-cache"
             then echo "already installed"
             else gh extension install actions/gh-actions-cache
           fi
 
-          if gh actions-cache list "${{ env.CACHE_KEY }}" | grep -q "${{ env.CACHE_KEY }}"
+          if gh actions-cache list --key "${{ env.CACHE_KEY }}" | grep -q "${{ env.CACHE_KEY }}"
             then echo "::set-output name=cache::hit"
             else echo "::set-output name=cache::miss"
           fi

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -7,6 +7,29 @@ on:
       - '.github/**npm**'
 
 jobs:
+
+  actions-test:
+    name: actions-test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: npm
+    steps:
+      - name: check cache is available
+        id: check-cache-available
+        env:
+          cache-key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('npm/package-lock.json') }}
+        run: |
+          if gh extension list | grep -q "gh-actions-cache"
+            then echo "already installed"
+            else gh extension install actions/gh-actions-cache
+          fi
+
+          if gh actions-cache list "${{ env.cache-key }}" | grep -q "${{ env.cache-key }}"
+            then echo "::set-output name=cache::hit"
+            else echo "::set-output name=cache::miss"
+          fi
+
   install:
     name: install
     runs-on: ubuntu-latest

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Cache Node packages
         uses: ./.github/compose/cache-npm
+        with:
+          token: ${{ secrets.GH_TOKEN}}
 
   build:
     name: build

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Restore node_modules
         uses: ./.github/compose/cache-npm
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache build
         uses: actions/cache@v3
@@ -91,6 +93,8 @@ jobs:
 
       - name: Restore node_modules
         uses: ./.github/compose/cache-npm
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: check cache is available

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -7,18 +7,17 @@ on:
       - '.github/**npm**'
 
 jobs:
-
+ 
   actions-test:
     name: actions-test
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: npm
     steps:
+      - uses: actions/checkout@v3
       - name: check cache is available
         id: check-cache-available
+        working-directory: npm
         env:
-          cache-key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('npm/package-lock.json') }}
+          cache-key: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
         run: |
           if gh extension list | grep -q "gh-actions-cache"
             then echo "already installed"

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -29,8 +29,6 @@ jobs:
             then echo "::set-output name=cache::hit"
             else echo "::set-output name=cache::miss"
           fi
-          # FIXME: remove
-          gh actions-cache list --key "${{ env.CACHE_KEY }}"
       - name: echo
         run: |
            echo ${{ steps.check-cache-available.outputs.cache }}

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -11,9 +11,8 @@ jobs:
   actions-test:
     name: actions-test
     runs-on: ubuntu-latest
-    # env:
-    #   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: check cache is available

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -17,15 +17,15 @@ jobs:
         id: check-cache-available
         working-directory: npm
         env:
-          cache-key: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
+          CACHE_KEY: ${{ runner.os }}-build-cache-npm-${{ hashFiles('npm/package-lock.json') }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh extension list | grep -q "gh-actions-cache"
+          if gh extension list ${{ env.CACHE_KEY }} | grep -q "gh-actions-cache"
             then echo "already installed"
             else gh extension install actions/gh-actions-cache
           fi
 
-          if gh actions-cache list "${{ env.cache-key }}" | grep -q "${{ env.cache-key }}"
+          if gh actions-cache list "${{ env.CACHE_KEY }}" | grep -q "${{ env.CACHE_KEY }}"
             then echo "::set-output name=cache::hit"
             else echo "::set-output name=cache::miss"
           fi

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Cache Node packages
         uses: ./.github/compose/cache-npm
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     name: build


### PR DESCRIPTION
This PR implements fast caching by removing unnecessary cache recovery .

## Background
In enterprises, a repository runs many jobs in parallel, so cache-miss costs more than expected.
For this reason, this workflow runs "install" at first to ensure subsequent jobs always has cache.
This reduces number of 'cache-miss' install to 1, but in this approach all jobs would be slower because of cache recovery.

actions/cache does not have an option to only checking cache, but gh cli offers that. 
